### PR TITLE
fix(utils): invert MSDB indexing

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,6 +2,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::iter::FromIterator;
 
 use std::fmt;
 
@@ -64,7 +65,7 @@ impl Graph {
 
     // remove returns a new graph with the specified nodes removed
     // TODO inefficient at the moment; may be faster ways.
-    pub fn remove(&self, nodes: &Vec<usize>) -> Graph {
+    pub fn remove(&self, nodes: &HashSet<usize>) -> Graph {
         let mut out = Vec::with_capacity(self.parents.len());
         for i in 0..self.parents.len() {
             let parents = self.parents.get(i).unwrap();
@@ -266,7 +267,7 @@ pub mod tests {
             algo: DRGAlgo::BucketSample,
         };
 
-        let nodes = vec![1, 3];
+        let nodes = HashSet::from_iter(vec![1, 3].iter().cloned());
         let g3 = g1.remove(&nodes);
         let expected = vec![vec![], vec![], vec![0], vec![], vec![2]];
         assert_eq!(g3.parents.len(), 5);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,19 +1,23 @@
 // msbd returns the most significant different bit index between the two given
-// numbers. The index is 0-based.
+// numbers. The index is 0-based counting from LSB to MSB.
 // if u and v are equal, it returns an index higher than than the bitsize.
 // TODO: make that generic for xorable values ?
 pub fn msbd(u: usize, v: usize) -> usize {
     let bitsize = node_bitsize();
     let xor = u ^ v;
-    let mut idx = 0; // index of the different bit
-    while idx < bitsize {
-        let diff = xor >> (bitsize - 1 - idx);
-        if diff == 1 {
+    if xor == 0 {
+        return bitsize + 1;
+        // FIXME: The +1 seems unnecessary, for a 0-based index
+        // the size is already out of bounds.
+    }
+
+    let mut idx = bitsize - 1; // index of the different bit
+    loop {
+        if xor & (1 << idx) > 0 {
             return idx;
         }
-        idx += 1;
+        idx -= 1;
     }
-    return bitsize + 1;
 }
 
 pub fn node_bitsize() -> usize {
@@ -26,9 +30,9 @@ mod test {
 
     #[test]
     fn test_msbd() {
-        assert_eq!(msbd(4, 2), 61);
-        assert_eq!(msbd(0, 2), 62);
-        assert_eq!(msbd(0, 1), 63);
-        assert_eq!(msbd(2, 3), 63);
+        assert_eq!(msbd(4, 2), 2);
+        assert_eq!(msbd(0, 2), 1);
+        assert_eq!(msbd(0, 1), 0);
+        assert_eq!(msbd(2, 3), 0);
     }
 }


### PR DESCRIPTION
Instead of counting from left (MSB) to right (LSB) do it from right to left so
the results will be independent of the size of the integers that code the node
indexes. For example,

* 63 -> 0 62 -> 1 61 -> 2

This change in the indexes caused some tests to fail (besides the MSDB one which
was expected), mainly because we were representing sets as vectors (so the same
results reordered failed). Change `Vec` to `HashSet` for partitions used in
Valiant.

NOTE: There is a particular test, `test_valiant_reduce`, that as a result of
this reordering returned a smaller `S` which sounds odd since `valiant_basic`
already orders the partitions to use the smallest ones first.